### PR TITLE
New Share Function

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -497,6 +497,14 @@ footer {
     border-radius: 10px;
 }
 
+#fallbackShare {
+    margin-top: 10px;
+}
+
+#copyMessage {
+    transition: opacity 0.3s ease-in-out;
+}
+
 .other-questions {
     text-align: center;
     font-size: 1.5em;

--- a/website/index.html
+++ b/website/index.html
@@ -42,10 +42,13 @@
                 <a href="faq.html" class="cta-button-link">
                     <button class="cta-button">FAQs</button>
                 </a>
-                <a href="https://twitter.com/intent/tweet?text=Teens!%20Get%20creative%20with%20BakeBuild%20and%20design%20your%20own%20cookie%20cutter!%20Exclusively%20for%20teen%20makers%20🚀🍪%20https://bakebuild.hackclub.com/%20%23bakebuild%20%23hackclub%20@hackclub"
-                    class="cta-button-link">
-                    <button class="cta-button">SHARE ON X</button>
-                </a>
+                <div id="shareContainer">
+                    <button id="shareButton" class="cta-button">SHARE</button>
+                </div>
+                <div id="fallbackShare" style="display: none; text-align: center;">
+                    <button id="copyLinkButton" class="cta-button">COPY LINK</button>
+                    <p id="copyMessage" style="color: green; font-weight: bold; margin-top: 5px; opacity: 0;">🔗 Link copied!</p>
+                </div>                           
             </div>
         </div>
         <section id="get-started">

--- a/website/js/script.js
+++ b/website/js/script.js
@@ -64,4 +64,40 @@ document.addEventListener("DOMContentLoaded", () => {
             button.textContent = "RSVP";
         }
     }
+
+    const shareButton = document.getElementById("shareButton");
+    const fallbackContainer = document.getElementById("fallbackShare");
+
+    const shareTitle = "BakeBuild - Design Your Own Cookie Cutter";
+    const shareText = "Teens! Get creative with BakeBuild and design your own cookie cutter! 🚀🍪";
+    const shareURL = "https://bakebuild.hackclub.com/";
+
+    if (navigator.share) {
+        shareButton.addEventListener("click", () => {
+            navigator.share({
+                title: shareTitle,
+                text: shareText,
+                url: shareURL
+            }).catch((error) => console.error("Error sharing:", error));
+        });
+    } else {
+
+        shareButton.style.display = "none";
+        fallbackContainer.style.display = "block";
+
+        const copyButton = document.getElementById("copyLinkButton");
+        const copyMessage = document.getElementById("copyMessage");
+
+        copyButton.addEventListener("click", () => {
+            navigator.clipboard.writeText(shareURL)
+                .then(() => {
+                    copyMessage.textContent = "🔗 Link copied!";
+                    copyMessage.style.opacity = "1";
+                    setTimeout(() => {
+                        copyMessage.style.opacity = "0";
+                    }, 3000);
+                })
+                .catch((err) => console.error("Error copying link:", err));
+        });
+    }
 });


### PR DESCRIPTION
After discussions and feedback on #meta, I’ve decided to use the default browser share API. It includes pre-filled text/messages, allowing users to choose where to share based on their platform.

If the browser’s share API isn’t available, it will fallback to a simple copy-to-clipboard option, ensuring all users can still share the link.

**Example on mac:**
This screenshot shows how the share button works on macOS, opening the native share menu with pre-filled content.

![image](https://github.com/user-attachments/assets/b4d5d61f-fb35-48a2-89a9-946d09ac0153)
![image](https://github.com/user-attachments/assets/8cb71887-fa03-4739-add8-5f2fdc48ef5a)