### PR TITLE
Add customizable <br> tag and make footer look cleaner

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -36,6 +36,12 @@ body {
     text-align: center;
 }
 
+br {
+    content: " ";
+    display: block;
+    margin-bottom: initial;
+}
+
 .cookie-border-left,
 .cookie-border-right {
     position: fixed;
@@ -409,12 +415,16 @@ section {
 footer {
     font-family: 'Fredoka One', sans-serif;
     font-size: 0.9em;
+    width: 90vw;
     color: #4f2f2f;
     background-color: #ffffff;
     padding: 15px 20px;
     text-align: center;
     border-top: 2px solid #cfb886;
     margin-top: 30px;
+    position: fixed;
+    border-radius: 20px 20px 0 0;
+    bottom: 0;
 }
 
 .faq-container {


### PR DESCRIPTION
The footer's small and sharp-cornered footprint looks out of place on a website that uses soft and rounded corners. Additionally, spacing is much easier with a customizable br size.