### PR TITLE
Fix z-index

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -423,6 +423,7 @@ footer {
     border-top: 2px solid #cfb886;
     margin-top: 30px;
     position: fixed;
+    z-index: 999;
     border-radius: 20px 20px 0 0;
     bottom: 0;
 }


### PR DESCRIPTION
The page elements go in front of the footer. This sets the z-index high enough that this should not happen.